### PR TITLE
Remove an unnecessary check from IsValidClient

### DIFF
--- a/scripting/retakes_autoplant.sp
+++ b/scripting/retakes_autoplant.sp
@@ -240,5 +240,5 @@ public bool TraceFilterIgnorePlayers(int entity, int contentsMask, int client)
 
 stock bool IsValidClient(int client)
 {
-    return client > 0 && client <= MaxClients && IsClientConnected(client) && IsClientInGame(client);
+    return client > 0 && client <= MaxClients && IsClientInGame(client);
 }


### PR DESCRIPTION
IsClientConnected is redundant as IsClientInGame already takes care of it.